### PR TITLE
PER TITLEリストでSHUFFを有効にしてアルバムロックをしていない時に、次のアルバムへ遷移する際に異常終了したり、不正にアルバムを…

### DIFF
--- a/game.c
+++ b/game.c
@@ -1406,6 +1406,11 @@ static void nextSong(int shuf)
 		/* shuffle mode */
 		if(_listType) {
 			while(1) {
+				for(songTop=0;;songTop++) {
+					if((_list[songTop].id & 0xFFFF00)>>8 == _title[ct].id) {
+						break;
+					}
+				}
 				for(i=0;i<_title[ct].songNum;i++) {
 					if(!_list[songTop+i].played && !_list[songTop+i].dis) {
 						break;


### PR DESCRIPTION
PER TITLEリストでSHUFFを有効にしてアルバムロックをしていない時に、次のアルバムへ遷移する際に異常終了したり、不正にアルバムをスキップすることがある不具合を修正。
