### PR TITLE
Android5以降で曲タイトルが表示されなくなる問題を修正

### DIFF
--- a/game.c
+++ b/game.c
@@ -676,8 +676,8 @@ int vge_loop()
         }
         if (_listType) {
             /* Draw song title */
-            putkanji(4 + bx, 134 + (int)base, 255, _title[ct].title);
-            putkanji(236 + bx - ((int)strlen(_title[ct].copyright)) * 4, 152 + (int)base, 255, _title[ct].copyright);
+            putkanji(4 + bx, 134 + (int)base, 255, "%s", _title[ct].title);
+            putkanji(236 + bx - ((int)strlen(_title[ct].copyright)) * 4, 152 + (int)base, 255, "%s", _title[ct].copyright);
             if (_title[ct].id == 0x60) {
                 putkanji((240 - (((int)strlen(_msg)) * 4)) / 2 + bx, 40 + (int)base, 255, "%s", _msg);
             }


### PR DESCRIPTION
### 問題内容

曲のタイトルとcopyrightの表示が欠損する（下記参照）
https://twitter.com/suzukiplan/status/675356355927015424
### 原因

Android 5以降で `vsnprintf` の仕様が次の様に変わったため:
- Android4以前: format-stringにロケール外MBCSが混入していても正常に文字列が組み立てられる
- Android5以降: format-stringにロケール外MBCSが混入しているとそこが `'\0'` に置換される
### 回避策
- a) format-string は `"%s"` にしておき、可変引数にロケール外MBCSを含む文字列ポインタを渡すことで回避可能
- b) ロケール外MBCSに format-string を含む場合は回避不可能なので `iconv` 等をするか `setlocale` をする必要があるものと考えられる
### 対策方法

回避策aでの回避を行う。
